### PR TITLE
gtls: fix ignored return and uninitialized status in OCSP check

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1427,7 +1427,7 @@ static CURLcode gtls_verify_ocsp_status(struct Curl_easy *data,
 {
   gnutls_ocsp_resp_t ocsp_resp = NULL;
   gnutls_datum_t status_request;
-  gnutls_ocsp_cert_status_t status;
+  gnutls_ocsp_cert_status_t status = GNUTLS_OCSP_CERT_UNKNOWN;
   gnutls_x509_crl_reason_t reason;
   CURLcode result = CURLE_OK;
   int rc;
@@ -1459,8 +1459,13 @@ static CURLcode gtls_verify_ocsp_status(struct Curl_easy *data,
     goto out;
   }
 
-  (void)gnutls_ocsp_resp_get_single(ocsp_resp, 0, NULL, NULL, NULL, NULL,
-                                    &status, NULL, NULL, NULL, &reason);
+  rc = gnutls_ocsp_resp_get_single(ocsp_resp, 0, NULL, NULL, NULL, NULL,
+                                   &status, NULL, NULL, NULL, &reason);
+  if(rc < 0) {
+    failf(data, "Invalid OCSP response received");
+    result = CURLE_SSL_INVALIDCERTSTATUS;
+    goto out;
+  }
 
   switch(status) {
   case GNUTLS_OCSP_CERT_GOOD:


### PR DESCRIPTION
## Summary

Two correctness bugs in `gtls_verify_ocsp_status` (`lib/vtls/gtls.c`), both introduced by aeb1a281ca:

- `gnutls_ocsp_resp_get_single()` was called with `(void)`, silently discarding its return value. An OCSP response with zero `SingleResponse` entries (or any other parse failure) went undetected.
- `gnutls_ocsp_cert_status_t status` was declared but never initialised. When `gnutls_ocsp_resp_get_single()` failed, the subsequent `switch(status)` read uninitialised memory — undefined behaviour that could yield `GNUTLS_OCSP_CERT_GOOD` (0) depending on stack contents, causing the function to return `CURLE_OK` for a response that was never successfully parsed.

These bugs only affect the `verifypeer=OFF, verifystatus=ON` configuration; with `verifypeer=ON`, `gnutls_certificate_verify_peers2()` validates the OCSP response before this function is reached. They are correctness/robustness bugs, not security vulnerabilities.

## Fix

- Initialise `status` to `GNUTLS_OCSP_CERT_UNKNOWN` so the `switch` always has a defined, safe value.
- Check the return value of `gnutls_ocsp_resp_get_single()` and treat failure as `CURLE_SSL_INVALIDCERTSTATUS`, consistent with all other error checks in the function.

## Test plan

- [ ] Build with GnuTLS backend and verify compilation is clean
- [ ] Confirm existing OCSP tests pass
- [ ] PoC: crafted OCSP response with zero `SingleResponse` entries now returns `CURLE_SSL_INVALIDCERTSTATUS` instead of `CURLE_OK`